### PR TITLE
chore: remove code coverage

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,0 +1,10 @@
+# enable color support of ls
+alias ls='ls --color=auto'
+
+# enable git autocompletion
+if [ -f /usr/share/bash-completion/completions/git ]; then
+    source /usr/share/bash-completion/completions/git
+fi
+
+# install pre-commit hooks
+pre-commit install

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "ms-vscode.cmake-tools",
                 "ms-vscode.cpptools"
             ],
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,5 @@
             }
         }
     },
-    "postStartCommand": "pre-commit --version && pre-commit install"
+    "postCreateCommand": "cp ${containerWorkspaceFolder}/.devcontainer/.bashrc /root/.bashrc"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,15 @@ cmake_minimum_required(VERSION 3.20)
 # export compile commands for clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# declare the project
 project(cli_example)
 
-# set C standard
 set(CMAKE_C_STANDARD 99 CACHE STRING "The C standard to use")
 
-# create a SRC_FILES variable with a link to all c files to compile
 set(SRC_FILES src/cli.c)
-
-# get the main file from the example/ dir and create executable
 add_executable(cli_example examples/main.c ${SRC_FILES})
-
-# set the directories that should be included in the build command for this target
 target_include_directories(cli_example PRIVATE src)
 
 if(TARGET_GROUP STREQUAL test)
-    enable_testing()
-    add_subdirectory(tests)
+  enable_testing()
+  add_subdirectory(tests)
 endif()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,6 @@ services:
     - build-image
     volumes:
     - ./:/app
-  code-coverage:
-    image: cli-embedded
-    command: bash -c "ceedling version && ceedling gcov:all utils:gcov"
-    depends_on:
-    - build-image
-    volumes:
-    - ./:/app
   static-analysis:
     image: cli-embedded
     command: bash -c "chmod +x static-analysis.sh && ./static-analysis.sh"

--- a/packages.txt
+++ b/packages.txt
@@ -4,7 +4,6 @@ clang-format
 clang-tidy
 cmake
 cppcheck
-gcovr
 gcc
 git
 nano


### PR DESCRIPTION
Removes the code coverage tool (requires `ceedling`).