### PR TITLE
feat: use asserts instead of error codes

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -31,22 +31,32 @@
  */
 #include "cli.h"
 
+#include <assert.h>
 #include <stdint.h>
 #include <string.h>
+
+/*!
+ * @brief   Custom assert function for unit testing.
+ * @details https://www.electronvector.com/blog/unit-testing-with-asserts
+ */
+#if TEST
+#undef assert
+#include "CException.h"
+#define assert(condition)                                                      \
+    if(!(condition))                                                           \
+    Throw(0)
+#endif
 
 static void cli_print(cli_t *cli, char *msg);
 
 cli_status_t cli_init(cli_t *cli, uint8_t *rx_buf_ptr, uint16_t rx_buf_size)
 {
-    if(cli->println == NULL || cli->cmd_tbl == NULL || rx_buf_ptr == NULL)
-    {
-        return CLI_E_NULL_PTR;
-    }
-
-    if(cli->cmd_cnt == 0 || rx_buf_size == 0)
-    {
-        return CLI_E_INVALID_ARGS;
-    }
+    assert(cli != NULL);
+    assert(cli->println != NULL);
+    assert(cli->cmd_tbl != NULL);
+    assert(cli->cmd_cnt != 0);
+    assert(rx_buf_ptr != NULL);
+    assert(rx_buf_size != 0);
 
     /* Reset buffer */
     cli->rx_data.current_buf_length = 0;
@@ -61,6 +71,8 @@ cli_status_t cli_init(cli_t *cli, uint8_t *rx_buf_ptr, uint16_t rx_buf_size)
 
 cli_status_t cli_process(cli_t *cli)
 {
+    assert(cli != NULL);
+
     uint8_t argc = 0;
     char *argv[MAX_ARGS];
 
@@ -108,6 +120,8 @@ cli_status_t cli_process(cli_t *cli)
 
 cli_status_t cli_put(cli_t *cli, char character)
 {
+    assert(cli != NULL);
+
     /* NOLINTNEXTLINE(hicpp-multiway-paths-covered) */
     switch(character)
     {
@@ -149,5 +163,7 @@ cli_status_t cli_put(cli_t *cli, char character)
 
 static void cli_print(cli_t *cli, char *msg)
 {
+    assert(cli != NULL);
+
     cli->println(msg);
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -36,7 +36,8 @@
 #include <string.h>
 
 /*!
- * @brief   Custom assert function for unit testing.
+ * @brief   Custom assert function that works with unit testing.
+ *
  * @details https://www.electronvector.com/blog/unit-testing-with-asserts
  */
 #if TEST

--- a/src/cli.c
+++ b/src/cli.c
@@ -165,6 +165,7 @@ cli_status_t cli_put(cli_t *cli, char character)
 static void cli_print(cli_t *cli, char *msg)
 {
     assert(cli != NULL);
+    assert(msg != NULL);
 
     cli->println(msg);
 }

--- a/src/cli_defs.h
+++ b/src/cli_defs.h
@@ -38,7 +38,6 @@
 typedef enum
 {
     CLI_OK,              /* API execution successful. */
-    CLI_E_NULL_PTR,      /* Null pointer error. */
     CLI_E_CMD_NOT_FOUND, /* Command name not found in command table. */
     CLI_E_INVALID_ARGS,  /* Invalid function parameters/arguments.   */
     CLI_E_BUF_FULL,      /* CLI buffer full.                         */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,8 +21,6 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(cexception)
 
-set(cexception_dir "${CMAKE_BINARY_DIR}/_deps/cexception-src/lib")
-
 # download fff.h directly, since meekrosoft/fff does not work with FetchContent
 set(fff_dir "${CMAKE_BINARY_DIR}/_deps/fff")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(FetchContent)
 
 set(unity_version "v2.6.1")
+set(cexception_version "v1.3.4")
 set(fff_version "v1.1")
 set(fff_hash MD5=10a2d739289c1054f6784fcc7203c8fd)
 
@@ -11,6 +12,16 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(unity)
+
+FetchContent_Declare(
+  cexception
+  GIT_REPOSITORY https://github.com/ThrowTheSwitch/CException.git
+  GIT_TAG ${cexception_version}
+)
+
+FetchContent_MakeAvailable(cexception)
+
+set(cexception_dir "${CMAKE_BINARY_DIR}/_deps/cexception-src/lib")
 
 # download fff.h directly, since meekrosoft/fff does not work with FetchContent
 set(fff_dir "${CMAKE_BINARY_DIR}/_deps/fff")

--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(check_assert)
 add_subdirectory(fake_printf)

--- a/tests/support/check_assert/CMakeLists.txt
+++ b/tests/support/check_assert/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(check_assert STATIC ${cexception_dir}/CException.c)
-target_include_directories(check_assert PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${cexception_dir})
+add_library(check_assert STATIC ${cexception_SOURCE_DIR}/lib/CException.c)
+target_include_directories(check_assert PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${cexception_SOURCE_DIR}/lib)
 target_link_libraries(check_assert PRIVATE unity)

--- a/tests/support/check_assert/CMakeLists.txt
+++ b/tests/support/check_assert/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(check_assert STATIC check_assert.c ${cexception_dir}/CException.c)
+add_library(check_assert STATIC ${cexception_dir}/CException.c)
 target_include_directories(check_assert PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${cexception_dir})
 target_link_libraries(check_assert PRIVATE unity)

--- a/tests/support/check_assert/CMakeLists.txt
+++ b/tests/support/check_assert/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(check_assert STATIC check_assert.c ${cexception_dir}/CException.c)
+target_include_directories(check_assert PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${cexception_dir})
+target_link_libraries(check_assert PRIVATE unity)

--- a/tests/support/check_assert/check_assert.c
+++ b/tests/support/check_assert/check_assert.c
@@ -1,1 +1,0 @@
-// empty file

--- a/tests/support/check_assert/check_assert.c
+++ b/tests/support/check_assert/check_assert.c
@@ -1,0 +1,1 @@
+// empty file

--- a/tests/support/check_assert/check_assert.h
+++ b/tests/support/check_assert/check_assert.h
@@ -1,0 +1,17 @@
+#ifndef CHECK_ASSERT_H
+#define CHECK_ASSERT_H
+
+#include "CException.h"
+
+#define SHOULD_FAIL_ASSERT(_code_under_test)                                   \
+    {                                                                          \
+        CEXCEPTION_T e;                                                        \
+        Try                                                                    \
+        {                                                                      \
+            _code_under_test;                                                  \
+            TEST_FAIL_MESSAGE("Code under test did not assert!");              \
+        }                                                                      \
+        Catch(e) {}                                                            \
+    }
+
+#endif // CHECK_ASSERT_H

--- a/tests/support/fake_printf/fake_printf.c
+++ b/tests/support/fake_printf/fake_printf.c
@@ -55,7 +55,7 @@ char *fake_printf_get_last_message(void)
     return message;
 }
 
-void fake_printf_reset(void)
+void fake_printf_clear(void)
 {
     /* open file in write mode to clear contents */
     FILE *file = fopen(FILE_NAME, "w");

--- a/tests/support/fake_printf/fake_printf.h
+++ b/tests/support/fake_printf/fake_printf.h
@@ -3,7 +3,7 @@
 
 int fake_printf(char *format, ...);
 char *fake_printf_get_last_message(void);
-void fake_printf_reset(void);
+void fake_printf_clear(void);
 void fake_printf_delete_file(void);
 
 #endif /* FAKE_PRINTF_H */

--- a/tests/test_cli/CMakeLists.txt
+++ b/tests/test_cli/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(test_cli test_cli.c ${CMAKE_SOURCE_DIR}/src/cli.c)
 target_compile_definitions(test_cli PUBLIC TEST)
 target_include_directories(test_cli PRIVATE ${CMAKE_SOURCE_DIR}/src ${fff_dir})
-target_link_libraries(test_cli PUBLIC unity fake_printf)
+target_link_libraries(test_cli PUBLIC unity check_assert fake_printf)
 add_test(test_cli test_cli)

--- a/tests/test_cli/test_cli.c
+++ b/tests/test_cli/test_cli.c
@@ -72,7 +72,9 @@ void initialize_cli(void)
 void setUp(void)
 {
     initialize_cli();
-    fake_printf_reset();
+
+    // clear "cli_init() ok" from fake printf
+    fake_printf_clear();
 }
 
 void tearDown(void)

--- a/tests/test_cli/test_cli.c
+++ b/tests/test_cli/test_cli.c
@@ -3,6 +3,8 @@
 #include "unity.h"
 
 #include "cli.h"
+
+#include "check_assert.h"
 #include "fake_printf.h"
 
 #include <stdarg.h>
@@ -191,9 +193,7 @@ void test_cli_init_should_failIfNullPointerPassed(void)
     bad_cli.cmd_tbl = cmd_tbl;
     bad_cli.cmd_cnt = (sizeof(cmd_tbl) / sizeof(cmd_t));
 
-    cli_result = cli_init(&bad_cli, NULL, sizeof(cli_buffer));
-
-    TEST_ASSERT_EQUAL(CLI_E_NULL_PTR, cli_result);
+    SHOULD_FAIL_ASSERT(cli_init(&bad_cli, NULL, sizeof(cli_buffer)));
 }
 
 void test_cli_init_should_failIfBufSizeIsZero(void)
@@ -205,9 +205,7 @@ void test_cli_init_should_failIfBufSizeIsZero(void)
     bad_cli.cmd_tbl = cmd_tbl;
     bad_cli.cmd_cnt = (sizeof(cmd_tbl) / sizeof(cmd_t));
 
-    cli_result = cli_init(&bad_cli, cli_buffer, 0);
-
-    TEST_ASSERT_EQUAL(CLI_E_INVALID_ARGS, cli_result);
+    SHOULD_FAIL_ASSERT(cli_init(&bad_cli, cli_buffer, 0));
 }
 
 void test_cli_process_should_returnNotFoundIfEmptyString(void)
@@ -232,7 +230,7 @@ int main(void)
     RUN_TEST(test_cli_process_should_callHelpIfHelpCmdReceived);
     RUN_TEST(test_cli_process_should_callArgsWithArgsIfArgsCmdReceived);
     RUN_TEST(test_cli_init_should_failIfNullPointerPassed);
-    RUN_TEST(test_cli_init_should_failIfBufSizeIsZero);
+    // RUN_TEST(test_cli_init_should_failIfBufSizeIsZero);
     RUN_TEST(test_cli_process_should_returnNotFoundIfEmptyString);
     return UNITY_END();
 }

--- a/tests/test_cli/test_cli.c
+++ b/tests/test_cli/test_cli.c
@@ -48,7 +48,7 @@ cli_status_t args_func(int argc, char **argv)
     return CLI_OK;
 }
 
-void setUp(void)
+void initialize_cli(void)
 {
     cli_status_t cli_result = CLI_MAX_STATUS;
     cli.println = fake_printf;
@@ -67,13 +67,16 @@ void setUp(void)
 
     TEST_ASSERT_EQUAL_STRING("cli_init() ok.\n",
                              fake_printf_get_last_message());
+}
 
+void setUp(void)
+{
+    initialize_cli();
     fake_printf_reset();
 }
 
 void tearDown(void)
 {
-    /* clear fake printf */
     fake_printf_delete_file();
 }
 
@@ -184,7 +187,19 @@ void test_cli_process_should_callArgsWithArgsIfArgsCmdReceived(void)
                              fake_printf_get_last_message());
 }
 
-void test_cli_init_should_failIfNullPointerPassed(void)
+void test_cli_init_should_failIfNullPointerPassedForCli(void)
+{
+    cli_t bad_cli;
+
+    cli_status_t cli_result = CLI_MAX_STATUS;
+    bad_cli.println = fake_printf;
+    bad_cli.cmd_tbl = cmd_tbl;
+    bad_cli.cmd_cnt = (sizeof(cmd_tbl) / sizeof(cmd_t));
+
+    SHOULD_FAIL_ASSERT(cli_init(NULL, cli_buffer, sizeof(cli_buffer)));
+}
+
+void test_cli_init_should_failIfNullPointerPassedForBufferPtr(void)
 {
     cli_t bad_cli;
 
@@ -229,8 +244,9 @@ int main(void)
     RUN_TEST(test_cli_process_should_returnNotFoundIfUnknownCommand);
     RUN_TEST(test_cli_process_should_callHelpIfHelpCmdReceived);
     RUN_TEST(test_cli_process_should_callArgsWithArgsIfArgsCmdReceived);
-    RUN_TEST(test_cli_init_should_failIfNullPointerPassed);
-    // RUN_TEST(test_cli_init_should_failIfBufSizeIsZero);
+    RUN_TEST(test_cli_init_should_failIfNullPointerPassedForCli);
+    RUN_TEST(test_cli_init_should_failIfNullPointerPassedForBufferPtr);
+    RUN_TEST(test_cli_init_should_failIfBufSizeIsZero);
     RUN_TEST(test_cli_process_should_returnNotFoundIfEmptyString);
     return UNITY_END();
 }


### PR DESCRIPTION
Replace error code returns with `assert` statements to enforce proper usage of the library.